### PR TITLE
Add Kustomize example

### DIFF
--- a/examples/kustomize/README.md
+++ b/examples/kustomize/README.md
@@ -1,0 +1,29 @@
+# Customizing env0 agent using Kustomize and Helm Post Render hooks
+env0 agent externalize an a wide array of values that may be set to configure the agent.  
+We do our best to support all common configuration case-scenarios, but sometimes a more exotic or pre-released configuration is required.  
+For such advanced cases, we offer this reference example of utilizing [kustomize](https://kustomize.io/) alongside [Helm Post Rendering](https://helm.sh/docs/topics/advanced/#post-rendering) to further customize our chart.  
+
+## Prerequisites
+- `kustomize` 3.5+ installed in your `PATH`
+- A running Kubernetes cluster
+- Helm 3.1+
+
+## The example
+This patches the resource limits of the `agent-trigger` deployment.  
+
+## Running the example
+
+```shell
+# Add the env0 repo if you haven't already
+helm repo add env0 https://env0.github.io/self-hosted
+helm repo update
+
+# Install the env0 chart
+helm upgrade --install --create-namespace env0-agent env0/env0-agent --namespace env0-agent \
+-f <your_agent_key>_values.yaml -f values.customer.yaml \
+--post-renderer ./kustomize-agent
+```
+
+## Modifying the example
+You may change the `kustomization.yaml` to target and patch the resources you wish to patch on the env0 agent installation.  
+

--- a/examples/kustomize/README.md
+++ b/examples/kustomize/README.md
@@ -1,5 +1,5 @@
 # Customizing env0 agent using Kustomize and Helm Post Render hooks
-env0 agent externalize an a wide array of values that may be set to configure the agent.  
+The env0 agent externalize an a wide array of values that may be set to configure the agent.  
 We do our best to support all common configuration case-scenarios, but sometimes a more exotic or pre-released configuration is required.  
 For such advanced cases, we offer this reference example of utilizing [kustomize](https://kustomize.io/) alongside [Helm Post Rendering](https://helm.sh/docs/topics/advanced/#post-rendering) to further customize our chart.  
 

--- a/examples/kustomize/kustomization.yaml
+++ b/examples/kustomize/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - env0.yaml
+patches:
+  - path: patch.yaml
+    target:
+      kind: Deployment
+      labelSelector: env0=agent-trigger

--- a/examples/kustomize/kustomize-agent
+++ b/examples/kustomize/kustomize-agent
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat <&0 > env0.yaml
+
+kustomize build . && rm env0.yaml

--- a/examples/kustomize/patch.yaml
+++ b/examples/kustomize/patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: doesNotMatter
+spec:
+  template:
+    spec:
+      containers:
+        - name: env0-agent-trigger
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 2000Mi


### PR DESCRIPTION
The env0 agent externalize an a wide array of values that may be set to configure the agent.  

We do our best to support all common configuration case-scenarios, but sometimes a more exotic or pre-released configuration is required.  

For such advanced cases, we offer this reference example of utilizing [kustomize](https://kustomize.io/) alongside [Helm Post Rendering](https://helm.sh/docs/topics/advanced/#post-rendering) to further customize our chart.  

This PR adds an example on how to do so.  